### PR TITLE
1.8.5

### DIFF
--- a/FlareLane/src/main/java/com/flarelane/BaseSharedPreferences.java
+++ b/FlareLane/src/main/java/com/flarelane/BaseSharedPreferences.java
@@ -45,7 +45,12 @@ class BaseSharedPreferences {
 
     public static boolean setProjectId(Context context, String projectId) {
         android.content.SharedPreferences.Editor editor = getSharedPreferences(context).edit();
-        editor.putString(PROJECT_ID_KEY, projectId);
+        if (projectId == null) {
+            editor.remove(PROJECT_ID_KEY);
+        } else {
+            editor.putString(PROJECT_ID_KEY, projectId);
+        }
+
         return editor.commit();
     }
 
@@ -57,7 +62,12 @@ class BaseSharedPreferences {
 
     public static boolean setPushToken(Context context, String pushToken) {
         android.content.SharedPreferences.Editor editor = getSharedPreferences(context).edit();
-        editor.putString(PUSH_TOKEN_KEY, pushToken);
+        if (pushToken == null) {
+            editor.remove(PUSH_TOKEN_KEY);
+        } else {
+            editor.putString(PUSH_TOKEN_KEY, pushToken);
+        }
+
         return editor.commit();
     }
 

--- a/FlareLane/src/main/java/com/flarelane/FlareLane.java
+++ b/FlareLane/src/main/java/com/flarelane/FlareLane.java
@@ -325,20 +325,31 @@ public class FlareLane {
         try {
             com.flarelane.Logger.verbose("resetDevice: Clearing all cached device data");
 
-            // Clear all cached device data
-            com.flarelane.BaseSharedPreferences.setDeviceId(context, null);
-            com.flarelane.BaseSharedPreferences.setUserId(context, null);
-            com.flarelane.BaseSharedPreferences.setIsSubscribed(context, false);
-            com.flarelane.BaseSharedPreferences.setPushToken(context, null);
-            com.flarelane.BaseSharedPreferences.setAlreadyPermissionAsked(context, false);
+            FlareLane.unsubscribe(context, null);
+            FlareLane.setUserId(context, null);
 
-            // Reset activation state to allow re-initialization
-            isActivated = false;
+            taskQueueManager.addTask(new NamedRunnable("trackEvent") {
+                @Override
+                public void run() {
+                    // Clear all cached device data
+                    com.flarelane.BaseSharedPreferences.setDeviceId(context, null);
+                    com.flarelane.BaseSharedPreferences.setUserId(context, null);
+                    com.flarelane.BaseSharedPreferences.setIsSubscribed(context, false);
+                    com.flarelane.BaseSharedPreferences.setPushToken(context, null);
+                    com.flarelane.BaseSharedPreferences.setAlreadyPermissionAsked(context, false);
+                    com.flarelane.BaseSharedPreferences.setProjectId(context, null);
 
-            // Reset task queue state
-            taskQueueManager.reset();
+                    // Reset activation state to allow re-initialization
+                    isActivated = false;
 
-            com.flarelane.Logger.verbose("resetDevice: Device data and task queue cleared successfully");
+                    // Reset task queue state
+                    taskQueueManager.reset();
+
+                    com.flarelane.Logger.verbose("resetDevice: Device data and task queue cleared successfully");
+                    completeTask();
+                }
+            });
+
         } catch (Exception e) {
             com.flarelane.BaseErrorHandler.handle(e);
         }

--- a/FlareLane/src/main/java/com/flarelane/FlareLane.java
+++ b/FlareLane/src/main/java/com/flarelane/FlareLane.java
@@ -325,28 +325,21 @@ public class FlareLane {
         try {
             com.flarelane.Logger.verbose("resetDevice: Clearing all cached device data");
 
-            taskQueueManager.addTask(new NamedRunnable("trackEvent") {
-                @Override
-                public void run() {
-                    // Clear all cached device data
-                    com.flarelane.BaseSharedPreferences.setDeviceId(context, null);
-                    com.flarelane.BaseSharedPreferences.setUserId(context, null);
-                    com.flarelane.BaseSharedPreferences.setIsSubscribed(context, false);
-                    com.flarelane.BaseSharedPreferences.setPushToken(context, null);
-                    com.flarelane.BaseSharedPreferences.setAlreadyPermissionAsked(context, false);
-                    com.flarelane.BaseSharedPreferences.setProjectId(context, null);
+            // Clear all cached device data
+            com.flarelane.BaseSharedPreferences.setDeviceId(context, null);
+            com.flarelane.BaseSharedPreferences.setUserId(context, null);
+            com.flarelane.BaseSharedPreferences.setIsSubscribed(context, false);
+            com.flarelane.BaseSharedPreferences.setPushToken(context, null);
+            com.flarelane.BaseSharedPreferences.setAlreadyPermissionAsked(context, false);
+            com.flarelane.BaseSharedPreferences.setProjectId(context, null);
 
-                    // Reset activation state to allow re-initialization
-                    isActivated = false;
+            // Reset activation state to allow re-initialization
+            isActivated = false;
 
-                    // Reset task queue state
-                    taskQueueManager.reset();
+            // Reset task queue state
+            taskQueueManager.reset();
 
-                    com.flarelane.Logger.verbose("resetDevice: Device data and task queue cleared successfully");
-                    completeTask();
-                }
-            });
-
+            com.flarelane.Logger.verbose("resetDevice: Device data and task queue cleared successfully");
         } catch (Exception e) {
             com.flarelane.BaseErrorHandler.handle(e);
         }

--- a/FlareLane/src/main/java/com/flarelane/FlareLane.java
+++ b/FlareLane/src/main/java/com/flarelane/FlareLane.java
@@ -325,9 +325,6 @@ public class FlareLane {
         try {
             com.flarelane.Logger.verbose("resetDevice: Clearing all cached device data");
 
-            FlareLane.unsubscribe(context, null);
-            FlareLane.setUserId(context, null);
-
             taskQueueManager.addTask(new NamedRunnable("trackEvent") {
                 @Override
                 public void run() {

--- a/FlareLane/src/main/java/com/flarelane/FlareLane.java
+++ b/FlareLane/src/main/java/com/flarelane/FlareLane.java
@@ -23,7 +23,7 @@ import org.json.JSONObject;
 public class FlareLane {
     public static class SdkInfo {
         public static SdkType type = SdkType.NATIVE;
-        public static String version = "1.8.4";
+        public static String version = "1.8.5";
     }
 
     protected static com.flarelane.NotificationForegroundReceivedHandler notificationForegroundReceivedHandler = null;
@@ -38,6 +38,7 @@ public class FlareLane {
 
     private static final com.flarelane.ActivityLifecycleManager activityLifecycleManager = new com.flarelane.ActivityLifecycleManager();
     private static final TaskQueueManager taskQueueManager = TaskQueueManager.getInstance();
+    private static final Throttler inAppMessageThrottler = new Throttler(500); // 0.5 seconds in milliseconds
 
     public static void initWithContext(Context context, String projectId, boolean requestPermissionOnLaunch) {
         try {
@@ -253,21 +254,27 @@ public class FlareLane {
     public static void displayInApp(Context context, String group, JSONObject data) {
         JSONObject ensureData = data != null ? data : new JSONObject();
 
-        taskQueueManager.addTask(new NamedRunnable("displayInApp") {
-            @Override
-            public void run() {
-                try {
-                    String projectId = com.flarelane.BaseSharedPreferences.getProjectId(context, false);
-                    String deviceId = com.flarelane.BaseSharedPreferences.getDeviceId(context, false);
-                    InAppService.getMessage(projectId, deviceId, group, ensureData, modelInAppMessage -> {
-                        FlareLaneInAppWebViewActivity.Companion.show(context, modelInAppMessage);
-                        completeTask();
-                        return null;
-                    });
-                } catch (Exception e) {
-                    com.flarelane.BaseErrorHandler.handle(e);
+        inAppMessageThrottler.throttle(() -> {
+            taskQueueManager.addTask(new NamedRunnable("displayInApp") {
+                @Override
+                public void run() {
+                    try {
+                        String projectId = com.flarelane.BaseSharedPreferences.getProjectId(context, false);
+                        String deviceId = com.flarelane.BaseSharedPreferences.getDeviceId(context, false);
+                        InAppService.getMessage(projectId, deviceId, group, ensureData, modelInAppMessage -> {
+                            if (modelInAppMessage != null) {
+                                FlareLaneInAppWebViewActivity.Companion.show(context, modelInAppMessage);
+                            }
+
+                            completeTask();
+                            return null;
+                        });
+                    } catch (Exception e) {
+                        com.flarelane.BaseErrorHandler.handle(e);
+                    }
                 }
-            }
+            });
+            return null;
         });
     }
 

--- a/FlareLane/src/main/java/com/flarelane/FlareLane.java
+++ b/FlareLane/src/main/java/com/flarelane/FlareLane.java
@@ -335,7 +335,10 @@ public class FlareLane {
             // Reset activation state to allow re-initialization
             isActivated = false;
 
-            com.flarelane.Logger.verbose("resetDevice: Device data cleared successfully");
+            // Reset task queue state
+            taskQueueManager.reset();
+
+            com.flarelane.Logger.verbose("resetDevice: Device data and task queue cleared successfully");
         } catch (Exception e) {
             com.flarelane.BaseErrorHandler.handle(e);
         }

--- a/FlareLane/src/main/java/com/flarelane/FlareLane.java
+++ b/FlareLane/src/main/java/com/flarelane/FlareLane.java
@@ -321,6 +321,26 @@ public class FlareLane {
         return false;
     }
 
+    public static void resetDevice(Context context) {
+        try {
+            com.flarelane.Logger.verbose("resetDevice: Clearing all cached device data");
+
+            // Clear all cached device data
+            com.flarelane.BaseSharedPreferences.setDeviceId(context, null);
+            com.flarelane.BaseSharedPreferences.setUserId(context, null);
+            com.flarelane.BaseSharedPreferences.setIsSubscribed(context, false);
+            com.flarelane.BaseSharedPreferences.setPushToken(context, null);
+            com.flarelane.BaseSharedPreferences.setAlreadyPermissionAsked(context, false);
+
+            // Reset activation state to allow re-initialization
+            isActivated = false;
+
+            com.flarelane.Logger.verbose("resetDevice: Device data cleared successfully");
+        } catch (Exception e) {
+            com.flarelane.BaseErrorHandler.handle(e);
+        }
+    }
+
     protected static void requestPermissionForNotifications(Context context, @Nullable IsSubscribedHandler handler) {
         Application application = (Application) context.getApplicationContext();
         int targetSdkVersion = application.getApplicationInfo().targetSdkVersion;

--- a/FlareLane/src/main/java/com/flarelane/InAppService.kt
+++ b/FlareLane/src/main/java/com/flarelane/InAppService.kt
@@ -36,6 +36,7 @@ internal object InAppService {
                             )
                             callback.invoke(model)
                         } else {
+                            callback.invoke(null)
                             Logger.verbose("There is no displayable IAM")
                         }
                     } catch (e: Exception) {

--- a/FlareLane/src/main/java/com/flarelane/TaskQueueManager.java
+++ b/FlareLane/src/main/java/com/flarelane/TaskQueueManager.java
@@ -101,4 +101,24 @@ class TaskQueueManager {
             processNext();
         }
     }
+
+    // Reset the task queue state and clear all pending tasks
+    public synchronized void reset() {
+        Logger.verbose("Resetting task queue state");
+
+        // Clear all pending tasks
+        taskQueue.clear();
+
+        // Reset processing state
+        isProcessing = false;
+        isInitialized = false;
+
+        // Cancel any pending timeout
+        if (timeoutRunnable != null) {
+            handler.removeCallbacks(timeoutRunnable);
+            timeoutRunnable = null;
+        }
+
+        Logger.verbose("Task queue reset completed");
+    }
 }

--- a/FlareLane/src/main/java/com/flarelane/Throttler.kt
+++ b/FlareLane/src/main/java/com/flarelane/Throttler.kt
@@ -1,0 +1,28 @@
+package com.flarelane
+
+import java.util.Date
+
+/**
+ * Throttler class to prevent rapid execution of actions
+ * Similar to iOS SDK implementation
+ */
+class Throttler(private val interval: Long) {
+    private var lastActionTime: Date = Date(0) // Equivalent to .distantPast in iOS
+
+    /**
+     * Execute action only if enough time has passed since last execution
+     * @param action The action to execute if throttling allows
+     */
+    fun throttle(action: () -> Unit) {
+        val now = Date()
+        val distance = now.time - lastActionTime.time
+
+        if (distance <= interval) {
+            Logger.verbose("Throttler exceeded.")
+            return
+        }
+
+        lastActionTime = now
+        action()
+    }
+}


### PR DESCRIPTION
- Add throttler for IAM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 인앱 메시지 연속 표시를 방지하는 500ms 스로틀링을 도입했습니다.
  - 기기·사용자 데이터 초기화 및 구독·활성화 상태·캐시·작업 큐를 재설정하는 공개 API(resetDevice)를 추가했습니다.
  - 작업 대기열 상태(큐, 처리 플래그, 타임아웃)를 초기화하는 공개 메서드(reset)를 추가했습니다.
- Bug Fixes
  - 인앱 메시지 응답이 비어있을 때도 콜백이 항상 호출되고 완료 처리되어 간헐적 중단/중복 표시 문제를 완화했습니다.
- Chores
  - SDK 버전을 1.8.5로 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->