### PR TITLE
[FL-1208] Notification Push 이벤트 dedup 처리

### DIFF
--- a/FlareLane/src/main/java/com/flarelane/EventService.kt
+++ b/FlareLane/src/main/java/com/flarelane/EventService.kt
@@ -8,6 +8,36 @@ internal object EventService {
     @JvmField
     var unhandledClickedNotification: Notification? = null
 
+    private const val CLICK_DEDUP_TTL_MS = 60_000L
+    private const val CLICK_DEDUP_MAX_SIZE = 256
+    private val processedClickIds = LinkedHashMap<String, Long>()
+
+    @Synchronized
+    private fun shouldSkipDuplicateClick(notificationId: String): Boolean {
+        val now = System.currentTimeMillis()
+        val iterator = processedClickIds.entries.iterator()
+        while (iterator.hasNext()) {
+            if (now - iterator.next().value > CLICK_DEDUP_TTL_MS) {
+                iterator.remove()
+            } else {
+                break
+            }
+        }
+        if (processedClickIds.containsKey(notificationId)) {
+            Logger.verbose("Duplicate notification click prevented: $notificationId")
+            return true
+        }
+        processedClickIds[notificationId] = now
+        if (processedClickIds.size > CLICK_DEDUP_MAX_SIZE) {
+            val oldest = processedClickIds.entries.iterator()
+            if (oldest.hasNext()) {
+                oldest.next()
+                oldest.remove()
+            }
+        }
+        return false
+    }
+
     @Throws(Exception::class)
     fun createNotificationClicked(
         projectId: String,
@@ -15,6 +45,10 @@ internal object EventService {
         notification: Notification,
         userId: String?
     ) {
+        if (shouldSkipDuplicateClick(notification.id)) {
+            return
+        }
+
         create(projectId, deviceId, notification.id, EventType.Clicked, userId)
 
         if (FlareLane.notificationClickedHandler != null) {

--- a/FlareLane/src/main/java/com/flarelane/EventService.kt
+++ b/FlareLane/src/main/java/com/flarelane/EventService.kt
@@ -1,6 +1,7 @@
 package com.flarelane
 
 import android.content.Context
+import android.os.SystemClock
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -14,7 +15,7 @@ internal object EventService {
 
     @Synchronized
     private fun shouldSkipDuplicateClick(notificationId: String): Boolean {
-        val now = System.currentTimeMillis()
+        val now = SystemClock.elapsedRealtime()
         val iterator = processedClickIds.entries.iterator()
         while (iterator.hasNext()) {
             if (now - iterator.next().value > CLICK_DEDUP_TTL_MS) {


### PR DESCRIPTION
click 이벤트가 중복발행되는 경우가 있어 우선 client 측에서 60초 짜리 로컬 캐시를 추가합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 동일 알림의 연속 클릭에 대한 중복 처리 방지 로직이 추가되었습니다. 같은 알림에 대한 반복 클릭은 60초 내에 무시되어 중복 이벤트 생성이 방지되며, 시스템 안정성과 성능이 향상됩니다. 내부 처리 항목 상한을 적용해 과도한 메모리 사용을 억제합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/flarelane/FlareLane-Android-SDK/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->