### PR TITLE
1.10.1

### DIFF
--- a/FlareLane/build.gradle
+++ b/FlareLane/build.gradle
@@ -26,6 +26,12 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    testOptions {
+        // Return safe defaults from stubbed android framework calls (e.g. android.util.Log)
+        // instead of throwing "not mocked" at runtime, so pure JVM unit tests can exercise
+        // classes that log without pulling in Robolectric.
+        unitTests.returnDefaultValues = true
+    }
 }
 
 dependencies {

--- a/FlareLane/src/main/java/com/flarelane/FlareLane.java
+++ b/FlareLane/src/main/java/com/flarelane/FlareLane.java
@@ -23,7 +23,7 @@ import org.json.JSONObject;
 public class FlareLane {
     public static class SdkInfo {
         public static SdkType type = SdkType.NATIVE;
-        public static String version = "1.10.0";
+        public static String version = "1.10.1";
     }
 
     protected static com.flarelane.NotificationForegroundReceivedHandler notificationForegroundReceivedHandler = null;

--- a/FlareLane/src/main/java/com/flarelane/HTTPClient.java
+++ b/FlareLane/src/main/java/com/flarelane/HTTPClient.java
@@ -46,6 +46,7 @@ class HTTPClient {
                     handleResponse(conn, responseHandler);
                 } catch (Exception e) {
                     com.flarelane.BaseErrorHandler.handle(e);
+                    notifyFailure(responseHandler);
                 } finally {
                     if (conn != null)
                         conn.disconnect();
@@ -99,12 +100,26 @@ class HTTPClient {
                     handleResponse(conn, responseHandler);
                 } catch (Exception e) {
                     com.flarelane.BaseErrorHandler.handle(e);
+                    notifyFailure(responseHandler);
                 } finally {
                     if (conn != null)
                         conn.disconnect();
                 }
             }
         }).start();
+    }
+
+    // Called from the outer catch blocks so every network-layer exception (URL
+    // build, connect, IO, or a bad handleResponse) still resolves the caller's
+    // handler. Without this, InAppService.getMessage would never see onFailure
+    // for these paths and the TaskQueueManager would stall until TIMEOUT_MS.
+    private static void notifyFailure(@Nullable ResponseHandler responseHandler) {
+        if (responseHandler == null) return;
+        try {
+            responseHandler.onFailure(-1, new JSONObject());
+        } catch (Exception e) {
+            com.flarelane.BaseErrorHandler.handle(e);
+        }
     }
 
     private static void handleResponse(HttpURLConnection conn, @Nullable ResponseHandler responseHandler) throws Exception {

--- a/FlareLane/src/main/java/com/flarelane/HTTPClient.java
+++ b/FlareLane/src/main/java/com/flarelane/HTTPClient.java
@@ -114,9 +114,22 @@ class HTTPClient {
     // handler. Without this, InAppService.getMessage would never see onFailure
     // for these paths and the TaskQueueManager would stall until TIMEOUT_MS.
     private static void notifyFailure(@Nullable ResponseHandler responseHandler) {
+        invokeSafely(responseHandler, false, -1, new JSONObject());
+    }
+
+    // Single dispatch site for handler callbacks. Swallowing exceptions here
+    // keeps them from bubbling into `sendRequestWithBody`'s outer catch, which
+    // would otherwise call `notifyFailure` and dispatch a second time. The
+    // handler contract is "exactly one of onSuccess/onFailure" — a partial
+    // dispatch that threw counts as the one call.
+    private static void invokeSafely(@Nullable ResponseHandler responseHandler, boolean success, int responseCode, JSONObject body) {
         if (responseHandler == null) return;
         try {
-            responseHandler.onFailure(-1, new JSONObject());
+            if (success) {
+                responseHandler.onSuccess(responseCode, body);
+            } else {
+                responseHandler.onFailure(responseCode, body);
+            }
         } catch (Exception e) {
             com.flarelane.BaseErrorHandler.handle(e);
         }
@@ -143,19 +156,12 @@ class HTTPClient {
             json = new JSONObject(response);
         } catch (org.json.JSONException e) {
             com.flarelane.Logger.error("Failed to parse response JSON: " + e + ", body: " + response);
-            if (responseHandler != null) {
-                responseHandler.onFailure(responseCode, new JSONObject());
-            }
+            invokeSafely(responseHandler, false, responseCode, new JSONObject());
             return;
         }
 
-        if (responseHandler != null) {
-            if (responseCode >= 200 && responseCode < 400) {
-                responseHandler.onSuccess(responseCode, json);
-            } else {
-                responseHandler.onFailure(responseCode, json);
-            }
-        }
+        boolean isSuccess = (responseCode >= 200 && responseCode < 400);
+        invokeSafely(responseHandler, isSuccess, responseCode, json);
     }
 
     private static String convertStreamToString(InputStream is) {

--- a/FlareLane/src/main/java/com/flarelane/InAppService.kt
+++ b/FlareLane/src/main/java/com/flarelane/InAppService.kt
@@ -5,6 +5,11 @@ import com.flarelane.model.ModelInAppMessage
 import org.json.JSONObject
 
 internal object InAppService {
+    // Written from the HTTP thread (getMessage entry + response callbacks) and read
+    // from the JS/main thread (Activity.finish resets on close). @Volatile guarantees
+    // cross-thread visibility so the guard never sees a stale `true` from an already
+    // completed request.
+    @Volatile
     var isDisplaying = false
 
     @JvmStatic

--- a/FlareLane/src/main/java/com/flarelane/InAppService.kt
+++ b/FlareLane/src/main/java/com/flarelane/InAppService.kt
@@ -9,8 +9,11 @@ internal object InAppService {
 
     @JvmStatic
     fun getMessage(projectId: String, deviceId: String, group: String, data: JSONObject, callback: (ModelInAppMessage?) -> Unit) {
+        // Every exit path must invoke `callback` exactly once so the TaskQueueManager's
+        // completeTask() is called and the queue can advance without waiting for TIMEOUT_MS.
         if (isDisplaying) {
             Logger.verbose("IAM is already displaying.")
+            callback.invoke(null)
             return
         }
         isDisplaying = true
@@ -19,30 +22,40 @@ internal object InAppService {
             .put("group", group)
             .put("data", data)
 
-
         HTTPClient.post(
             "internal/v1/projects/$projectId/devices/$deviceId/in-app-messages?group=$group",
             body,
             object : ResponseHandler() {
                 override fun onSuccess(responseCode: Int, response: JSONObject) {
-                    try {
-                        isDisplaying = false
-                        val jsonArray = response.getJSONArray("data")
-                        if (jsonArray.length() > 0) {
-                            val jsonObject = jsonArray.getJSONObject(0)
-                            val model = ModelInAppMessage(
-                                id = jsonObject.getString("id"),
-                                htmlString = jsonObject.getString("htmlString")
-                            )
-                            callback.invoke(model)
-                        } else {
-                            callback.invoke(null)
-                            Logger.verbose("There is no displayable IAM")
-                        }
-                    } catch (e: Exception) {
-                        BaseErrorHandler.handle(e)
-                    }
+                    isDisplaying = false
+                    callback.invoke(parseFirstMessage(response))
+                }
+
+                override fun onFailure(responseCode: Int, response: JSONObject) {
+                    isDisplaying = false
+                    Logger.error("getMessage onFailure: code=$responseCode body=$response")
+                    callback.invoke(null)
                 }
             })
+    }
+
+    // Extracted for testability: no I/O, no state mutation. Returns null on empty data
+    // or malformed payload — callers use that as the "nothing to show" signal.
+    internal fun parseFirstMessage(response: JSONObject): ModelInAppMessage? {
+        return try {
+            val jsonArray = response.getJSONArray("data")
+            if (jsonArray.length() == 0) {
+                Logger.verbose("There is no displayable IAM")
+                return null
+            }
+            val jsonObject = jsonArray.getJSONObject(0)
+            ModelInAppMessage(
+                id = jsonObject.getString("id"),
+                htmlString = jsonObject.getString("htmlString")
+            )
+        } catch (e: Exception) {
+            BaseErrorHandler.handle(e)
+            null
+        }
     }
 }

--- a/FlareLane/src/test/java/com/flarelane/InAppServiceTest.kt
+++ b/FlareLane/src/test/java/com/flarelane/InAppServiceTest.kt
@@ -1,0 +1,92 @@
+package com.flarelane
+
+import com.flarelane.model.ModelInAppMessage
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Specs for the InAppService callback contract: every exit path in `getMessage` must invoke
+ * the caller-supplied callback exactly once, and `parseFirstMessage` must never throw. Both
+ * guarantees are what keep the FlareLane TaskQueueManager from stalling for TIMEOUT_MS (10s)
+ * when a fetch fails or the response body is unexpected.
+ */
+class InAppServiceTest {
+
+    @After
+    fun tearDown() {
+        // Reset shared state so tests do not leak into each other.
+        InAppService.isDisplaying = false
+    }
+
+    @Test
+    fun `getMessage invokes callback with null when isDisplaying guard fires`() {
+        InAppService.isDisplaying = true
+
+        var callCount = 0
+        var received: ModelInAppMessage? = ModelInAppMessage(id = "sentinel", htmlString = "sentinel")
+        InAppService.getMessage("p", "d", "g", JSONObject()) { model ->
+            callCount++
+            received = model
+        }
+
+        // Guard path must invoke exactly once with null; the flag stays true because the
+        // in-flight request that set it is still expected to reset it on completion.
+        assertEquals(1, callCount)
+        assertNull(received)
+    }
+
+    @Test
+    fun `parseFirstMessage returns model for well-formed response`() {
+        val response = JSONObject().put(
+            "data", JSONArray().put(
+                JSONObject()
+                    .put("id", "msg-1")
+                    .put("htmlString", "<html></html>")
+            )
+        )
+
+        val model = InAppService.parseFirstMessage(response)
+
+        assertNotNull(model)
+        assertEquals("msg-1", model!!.id)
+        assertEquals("<html></html>", model.htmlString)
+    }
+
+    @Test
+    fun `parseFirstMessage returns null when data array is empty`() {
+        val response = JSONObject().put("data", JSONArray())
+
+        assertNull(InAppService.parseFirstMessage(response))
+    }
+
+    @Test
+    fun `parseFirstMessage returns null when data field is missing`() {
+        // No `data` key — previously threw JSONException that was caught silently without
+        // notifying the caller. Now returns null so the caller can complete its task.
+        val response = JSONObject().put("unrelated", "value")
+
+        assertNull(InAppService.parseFirstMessage(response))
+    }
+
+    @Test
+    fun `parseFirstMessage returns null when first entry is missing required fields`() {
+        val response = JSONObject().put(
+            "data", JSONArray().put(JSONObject().put("id", "msg-1"))
+            // missing "htmlString"
+        )
+
+        assertNull(InAppService.parseFirstMessage(response))
+    }
+
+    @Test
+    fun `parseFirstMessage returns null when data is not an array`() {
+        val response = JSONObject().put("data", "not-an-array")
+
+        assertNull(InAppService.parseFirstMessage(response))
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 인앱 메시지 요청 시 콜백이 모든 경로에서 정확히 1회 호출되도록 정리하고, 중복 표시 상황에서도 안전하게 처리했습니다.
  * 네트워크/응답 처리 중 예외가 발생해도 실패 콜백이 정상 전달되도록 개선했습니다.
  * 잘못된 인앱 메시지 응답 형식에서는 파싱 실패로 인한 문제를 줄이도록 대응했습니다.
* **개선 사항**
  * SDK 버전을 1.10.1로 업데이트했습니다.
* **테스트**
  * 인앱 메시지 요청/파싱과 콜백 계약을 검증하는 테스트를 추가했습니다.
  * JVM 단위 테스트에서 Android 로깅 관련 호출이 안전하게 동작하도록 설정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->