### PR TITLE
1.10.2

### DIFF
--- a/FlareLane/src/main/AndroidManifest.xml
+++ b/FlareLane/src/main/AndroidManifest.xml
@@ -47,6 +47,7 @@
             android:theme="@style/Theme.AppCompat.NoActionBar" />
         <activity
             android:name=".webview.FlareLaneInAppWebViewActivity"
+            android:configChanges="orientation|screenSize|keyboardHidden"
             android:exported="false"
             android:hardwareAccelerated="true"
             android:theme="@android:style/Theme.Translucent.NoTitleBar" />

--- a/FlareLane/src/main/java/com/flarelane/FlareLane.java
+++ b/FlareLane/src/main/java/com/flarelane/FlareLane.java
@@ -13,7 +13,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 
-import com.flarelane.webview.FlareLaneInAppWebViewActivity;
+import com.flarelane.webview.InAppMessagePresenter;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
 
@@ -23,7 +23,7 @@ import org.json.JSONObject;
 public class FlareLane {
     public static class SdkInfo {
         public static SdkType type = SdkType.NATIVE;
-        public static String version = "1.10.1";
+        public static String version = "1.10.2";
     }
 
     protected static com.flarelane.NotificationForegroundReceivedHandler notificationForegroundReceivedHandler = null;
@@ -286,7 +286,9 @@ public class FlareLane {
                         String deviceId = com.flarelane.BaseSharedPreferences.getDeviceId(context, false);
                         InAppService.getMessage(projectId, deviceId, group, ensureData, modelInAppMessage -> {
                             if (modelInAppMessage != null) {
-                                FlareLaneInAppWebViewActivity.Companion.show(context, modelInAppMessage);
+                                // Loads the html first and starts the Activity once it is
+                                // ready, so the host app is never covered while loading.
+                                InAppMessagePresenter.INSTANCE.present(context, modelInAppMessage);
                             }
 
                             completeTask();

--- a/FlareLane/src/main/java/com/flarelane/webview/FlareLaneInAppWebViewActivity.kt
+++ b/FlareLane/src/main/java/com/flarelane/webview/FlareLaneInAppWebViewActivity.kt
@@ -1,89 +1,60 @@
 package com.flarelane.webview
 
-import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.graphics.Bitmap
-import android.graphics.Color
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.view.View
-import android.webkit.WebChromeClient
-import android.webkit.WebSettings
+import android.view.ViewGroup
+import android.widget.FrameLayout
 import android.webkit.WebView
-import android.webkit.WebViewClient
 import com.flarelane.FlareLane
 import com.flarelane.InAppService
+import com.flarelane.Logger
 import com.flarelane.R
-import com.flarelane.model.ModelInAppMessage
 import com.flarelane.util.IntentUtil
 import com.flarelane.webview.jsinterface.FlareLaneInAppJavascriptInterface
-import com.flarelane.webview.jsinterface.FlareLaneJavascriptInterface
 
 
 internal class FlareLaneInAppWebViewActivity : Activity(),
     FlareLaneInAppJavascriptInterface.Listener {
-    private lateinit var webView: WebView
+    // Owned by InAppMessagePresenter, which created and loaded it before this
+    // Activity was started.
+    private var webView: WebView? = null
 
-    @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val id = if (intent.hasExtra(ID)) {
-            intent.getStringExtra(ID)
-        } else {
-            null
-        }
-
-        val htmlString = if (intent.hasExtra(HTML_STRING)) {
-            intent.getStringExtra(HTML_STRING)
-        } else {
-            null
-        }
-
-        if (id.isNullOrEmpty() || htmlString.isNullOrEmpty()) {
+        val webView = InAppMessagePresenter.consumeWebView(this)
+        if (webView == null) {
+            Logger.error("There is no preloaded IAM to display.")
             finish()
             return
         }
+        this.webView = webView
 
         setContentView(R.layout.activity_inapp_webview)
 
-        webView = findViewById(R.id.web_view)
-        webView.visibility = View.INVISIBLE
-
-        with(webView) {
-            webChromeClient = flWebChromeClient
-            webViewClient = flWebViewClient
-            addJavascriptInterface(
-                FlareLaneInAppJavascriptInterface(
-                    this@FlareLaneInAppWebViewActivity,
-                    id,
-                    this@FlareLaneInAppWebViewActivity
-                ),
-                FlareLaneInAppJavascriptInterface.BRIDGE_NAME
+        val container = findViewById<FrameLayout>(R.id.web_view_container)
+        (webView.parent as? ViewGroup)?.removeView(webView)
+        container.addView(
+            webView,
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT
             )
-            webView.setBackgroundColor(Color.TRANSPARENT)
-        }
-
-        with(webView.settings) {
-            cacheMode = WebSettings.LOAD_NO_CACHE
-            javaScriptEnabled = true
-            domStorageEnabled = true
-            loadWithOverviewMode = true
-            useWideViewPort = true
-            allowFileAccess = true
-            javaScriptCanOpenWindowsAutomatically = true
-        }
-
-        webView.loadDataWithBaseURL(null, htmlString, "text/html; charset=utf-8", "utf-8", null)
+        )
+        // The html is already loaded, so there is nothing left to wait for.
+        webView.visibility = View.VISIBLE
     }
 
     @Deprecated("Deprecated in Java")
     override fun onBackPressed() {
         super.onBackPressed()
-        if (webView.canGoBack()) {
+        val webView = this.webView
+        if (webView != null && webView.canGoBack()) {
             webView.goBack()
         } else {
             finish()
@@ -92,9 +63,15 @@ internal class FlareLaneInAppWebViewActivity : Activity(),
 
     override fun onStop() {
         super.onStop()
-        if (webView.originalUrl.isNullOrEmpty()) {
+        if (webView?.originalUrl.isNullOrEmpty()) {
             super.finish()
         }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        InAppMessagePresenter.release()
+        webView = null
     }
 
     override fun finish() {
@@ -134,34 +111,13 @@ internal class FlareLaneInAppWebViewActivity : Activity(),
         finish()
     }
 
-    private val flWebChromeClient = object : WebChromeClient() {
-        override fun getDefaultVideoPoster(): Bitmap {
-            return Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
-        }
-
-        override fun onProgressChanged(view: WebView, newProgress: Int) {
-        }
-    }
-
-    private val flWebViewClient = object : WebViewClient() {
-        override fun onPageFinished(view: WebView?, url: String?) {
-            super.onPageFinished(view, url)
-            webView.visibility = View.VISIBLE
-        }
-    }
-
     companion object {
-        private const val ID = "id"
-        private const val HTML_STRING = "html_string"
-
-        fun show(context: Context, modelInAppMessage: ModelInAppMessage) {
+        fun show(context: Context) {
             context.startActivity(
                 Intent(context, FlareLaneInAppWebViewActivity::class.java).also {
                     it.flags = Intent.FLAG_ACTIVITY_NEW_TASK or
                             Intent.FLAG_ACTIVITY_CLEAR_TOP or
                             Intent.FLAG_ACTIVITY_SINGLE_TOP
-                    it.putExtra(ID, modelInAppMessage.id)
-                    it.putExtra(HTML_STRING, modelInAppMessage.htmlString)
                 }
             )
         }

--- a/FlareLane/src/main/java/com/flarelane/webview/InAppMessagePresenter.kt
+++ b/FlareLane/src/main/java/com/flarelane/webview/InAppMessagePresenter.kt
@@ -1,0 +1,222 @@
+package com.flarelane.webview
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.os.Handler
+import android.os.Looper
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import com.flarelane.Logger
+import com.flarelane.model.ModelInAppMessage
+import com.flarelane.webview.jsinterface.FlareLaneInAppJavascriptInterface
+
+/**
+ * Loads the message html into an off-window WebView and starts
+ * [FlareLaneInAppWebViewActivity] only after the page has finished loading.
+ *
+ * The Activity is translucent and full-screen, so starting it before the html is
+ * ready leaves an invisible window on top of the host app: it swallows touches and
+ * pauses the underlying Activity for as long as the html's remote resources take to
+ * download. Loading first and presenting afterwards matches the iOS SDK, which
+ * creates its UIWindow in `didFinishNavigation`.
+ *
+ * All state here is confined to the main thread; bridge callbacks arriving on the
+ * JavaBridge thread are posted back before touching it.
+ */
+internal object InAppMessagePresenter : FlareLaneInAppJavascriptInterface.Listener {
+
+    // Upper bound on the invisible load phase. A single stalled font or image must
+    // not sink the message entirely, so present with whatever has painted so far.
+    private const val LOAD_TIMEOUT_MS = 5000L
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    private var pending: Pending? = null
+
+    // Set once the Activity is on screen. Bridge callbacks are forwarded to it from
+    // then on; before that only `onClose` is meaningful (html can close itself while
+    // loading, e.g. from its own frequency-cap script).
+    private var attachedListener: FlareLaneInAppJavascriptInterface.Listener? = null
+
+    private class Pending(
+        val appContext: Context,
+        val message: ModelInAppMessage,
+        val webView: WebView
+    ) {
+        var isSettled = false
+        var timeoutRunnable: Runnable? = null
+    }
+
+    /**
+     * Begins loading [message]. The Activity is started later, from [settle].
+     * Safe to call from any thread.
+     */
+    fun present(context: Context, message: ModelInAppMessage) {
+        val appContext = context.applicationContext
+
+        mainHandler.post {
+            if (pending != null) {
+                Logger.verbose("IAM is already being presented.")
+                return@post
+            }
+
+            try {
+                val webView = createWebView(appContext, message)
+                val current = Pending(appContext, message, webView)
+                pending = current
+
+                val timeoutRunnable = Runnable {
+                    Logger.error("IAM load exceeded ${LOAD_TIMEOUT_MS}ms, displaying as-is.")
+                    settle()
+                }
+                current.timeoutRunnable = timeoutRunnable
+                mainHandler.postDelayed(timeoutRunnable, LOAD_TIMEOUT_MS)
+
+                webView.loadDataWithBaseURL(
+                    null,
+                    message.htmlString,
+                    "text/html; charset=utf-8",
+                    "utf-8",
+                    null
+                )
+            } catch (e: Exception) {
+                Logger.error("Failed to preload IAM.", e)
+                discard()
+            }
+        }
+    }
+
+    /**
+     * Hands the loaded WebView over to the Activity. Called by
+     * [FlareLaneInAppWebViewActivity.onCreate]; returns null when there is nothing
+     * to display, in which case the Activity finishes immediately.
+     */
+    fun consumeWebView(listener: FlareLaneInAppJavascriptInterface.Listener): WebView? {
+        val current = pending ?: return null
+        attachedListener = listener
+        return current.webView
+    }
+
+    /** Called when the Activity is destroyed, so the WebView is not leaked. */
+    fun release() {
+        mainHandler.post { discard() }
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun createWebView(appContext: Context, message: ModelInAppMessage): WebView {
+        return WebView(appContext).apply {
+            // Stays invisible until the Activity attaches it, so a partially painted
+            // page is never shown.
+            visibility = View.INVISIBLE
+            setBackgroundColor(Color.TRANSPARENT)
+
+            webChromeClient = object : WebChromeClient() {
+                override fun getDefaultVideoPoster(): Bitmap {
+                    return Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+                }
+            }
+
+            webViewClient = object : WebViewClient() {
+                override fun onPageFinished(view: WebView?, url: String?) {
+                    super.onPageFinished(view, url)
+                    settle()
+                }
+
+                override fun onReceivedError(
+                    view: WebView?,
+                    request: WebResourceRequest?,
+                    error: WebResourceError?
+                ) {
+                    super.onReceivedError(view, request, error)
+                    // Sub-resource failures still leave a presentable message; only a
+                    // failed document means there is nothing to show.
+                    if (request?.isForMainFrame == true) {
+                        Logger.error("Failed to load IAM document: ${error?.description}")
+                        discard()
+                    }
+                }
+            }
+
+            addJavascriptInterface(
+                FlareLaneInAppJavascriptInterface(
+                    appContext,
+                    message.id,
+                    InAppMessagePresenter
+                ),
+                FlareLaneInAppJavascriptInterface.BRIDGE_NAME
+            )
+
+            with(settings) {
+                cacheMode = WebSettings.LOAD_NO_CACHE
+                javaScriptEnabled = true
+                domStorageEnabled = true
+                loadWithOverviewMode = true
+                useWideViewPort = true
+                allowFileAccess = true
+                javaScriptCanOpenWindowsAutomatically = true
+            }
+        }
+    }
+
+    /** The page is ready (or out of time): put it on screen exactly once. */
+    private fun settle() {
+        val current = pending ?: return
+        if (current.isSettled) return
+        current.isSettled = true
+
+        current.timeoutRunnable?.let { mainHandler.removeCallbacks(it) }
+        current.timeoutRunnable = null
+
+        FlareLaneInAppWebViewActivity.show(current.appContext)
+    }
+
+    private fun discard() {
+        val current = pending ?: return
+        current.timeoutRunnable?.let { mainHandler.removeCallbacks(it) }
+        pending = null
+        attachedListener = null
+
+        with(current.webView) {
+            (parent as? ViewGroup)?.removeView(this)
+            stopLoading()
+            destroy()
+        }
+    }
+
+    override fun requestPushPermission(fallbackToSettings: Boolean) {
+        val listener = attachedListener
+        if (listener == null) {
+            Logger.verbose("requestPushPermission ignored: IAM is not displayed yet.")
+            return
+        }
+        listener.requestPushPermission(fallbackToSettings)
+    }
+
+    override fun onOpenUrl(url: String) {
+        val listener = attachedListener
+        if (listener == null) {
+            Logger.verbose("openUrl ignored: IAM is not displayed yet.")
+            return
+        }
+        listener.onOpenUrl(url)
+    }
+
+    override fun onClose() {
+        val listener = attachedListener
+        if (listener != null) {
+            listener.onClose()
+            return
+        }
+        // The html closed itself while still loading, so it never becomes visible.
+        Logger.verbose("IAM closed itself before display.")
+        mainHandler.post { discard() }
+    }
+}

--- a/FlareLane/src/main/res/layout/activity_inapp_webview.xml
+++ b/FlareLane/src/main/res/layout/activity_inapp_webview.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- The WebView is created and loaded by InAppMessagePresenter before this Activity
+     starts, then attached here in onCreate. -->
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/web_view_container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-    <WebView
-        android:id="@+id/web_view"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:scrollbars="none" />
-
-</FrameLayout>
+    android:layout_height="match_parent" />


### PR DESCRIPTION
## 원인

인앱메시지 Activity는 투명한 전체화면인데, 조회 API 응답 직후 html 로딩이 끝나기 전에 시작되고 있었습니다. 그 결과 로딩이 끝날 때까지 보이지 않는 창이 앱 위에 떠서 터치를 흡수하고, 아래 Activity는 `onPause` 상태가 됩니다. html이 외부 폰트·이미지를 참조하면 그만큼 앱이 멈춘 것처럼 보입니다.

## 변경 사항

- html을 화면에 붙지 않은 WebView에서 먼저 로드하고, `onPageFinished` 이후에 Activity를 시작하도록 순서를 바꿨습니다. iOS SDK가 `didFinishNavigation`에서 `UIWindow`를 만드는 것과 동일한 타이밍입니다.
- 로딩 상한 5초를 둬서 리소스 하나가 응답하지 않아도 메시지가 표시되게 했습니다. 문서 자체 로드 실패 시에는 표시하지 않습니다.
- 로딩 중 html이 스스로 `close()`를 호출하면 Activity를 시작하지 않습니다.
- 회전으로 Activity가 재생성되며 로드된 WebView가 버려지지 않도록 `configChanges`를 추가했습니다.

큐 진행을 막지 않기 위해 `completeTask()`는 기존과 같이 조회 완료 직후에 호출합니다.

## 확인

- `:FlareLane:compileDebugKotlin`, `:FlareLane:compileDebugJavaWithJavac` 통과
- 실기기에서 노출 시점과 터치 정상 동작 확인 필요